### PR TITLE
Update wasm-bindgen

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Because `pure-evm` is loaded as a WebAssembly module in browser, it must be load
 
 For example,
 
-```
+```javascript
 import('pure-evm').then((pure_evm) => {
 
   let output = pure_evm.exec(bytecode(), data())
@@ -51,7 +51,7 @@ function data() {
 
 In node environments, `pure-evm` can be used in a similar way.
 
-```
+```javascript
 const pure_evm = require('pure-evm');
 ...
 ```

--- a/wasm/Cargo.toml
+++ b/wasm/Cargo.toml
@@ -9,4 +9,4 @@ crate-type = ["cdylib"]
 
 [dependencies]
 pure-evm = { path = "../" }
-wasm-bindgen = "0.2"
+wasm-bindgen = "0.2.55"

--- a/wasm/build.sh
+++ b/wasm/build.sh
@@ -24,7 +24,7 @@ PKG_NAME="pure-evm"
 
 # Build for both targets.
 wasm-pack build -t nodejs -d pkg-node --out-name $PKG_NAME
-wasm-pack build -t browser -d pkg --out-name $PKG_NAME
+wasm-pack build -t bundler -d pkg --out-name $PKG_NAME
 
 # Merge nodejs & browser packages.
 cp "pkg-node/${PKG_NAME}.js" "pkg/${PKG_NAME}_main.js"


### PR DESCRIPTION
Updates `wasm-bindgen` and also swaps to use `bundler` as the output target instead of `browser` which is the updated version of that target.